### PR TITLE
jsonのis_openがBooleanではなく数値になってしまっていたのを修正した

### DIFF
--- a/server/laravel/app/Models/DoorLog.php
+++ b/server/laravel/app/Models/DoorLog.php
@@ -12,6 +12,10 @@ class DoorLog extends Model
 
     protected $fillable = ['is_open'];
 
+    protected $casts = [
+        'is_open' => 'boolean'
+    ];
+
     public function device()
     {
         return $this->belongsTo(Device::class);


### PR DESCRIPTION
JSONの出力のis_openがBooleanであるべきはずなのに数値で表示されてしまっていたので
適切に表示されるように修正した。